### PR TITLE
fix: Hide flickering from user

### DIFF
--- a/app/providers/stats/solanaDashboardInfo.tsx
+++ b/app/providers/stats/solanaDashboardInfo.tsx
@@ -111,7 +111,8 @@ export function dashboardInfoReducer(state: DashboardInfo, action: DashboardInfo
 
             // interpolate blocktime based on last known blocktime and average slot time
             if (
-                state.lastBlockTime &&
+                state.lastBlockTime && 
+                state.lastBlockTime.blockTime !== 0 &&
                 state.avgSlotTime_1h !== 0 &&
                 action.data.absoluteSlot >= state.lastBlockTime.slot
             ) {


### PR DESCRIPTION
We've seen an issue where the cluster time flickers back and forth between the current time and a default time of 1/1/1970. This PR doesn't fix the issue, just hides it from the user. See [additional context](https://nitro-svm.slack.com/archives/C070HSCT4TY/p1745480920527379?thread_ts=1744923571.503099&cid=C070HSCT4TY).