### PR TITLE
fix: Make accounts page and transactions page display correctly

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -216,7 +216,7 @@ function AddressLayoutInner({ children, params: { address } }: Props) {
         if (!info && status === ClusterStatus.Connected && pubkey) {
             fetchAccount(pubkey, 'parsed');
         }
-    }, [address, status]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [address, status, info, fetchAccount]);
 
     return (
         <div className="container mt-n3">

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -216,7 +216,7 @@ function AddressLayoutInner({ children, params: { address } }: Props) {
         if (!info && status === ClusterStatus.Connected && pubkey) {
             fetchAccount(pubkey, 'parsed');
         }
-    }, [address, status, info, fetchAccount]);
+    }, [address, status]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <div className="container mt-n3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,7 +177,7 @@ function StatsCardBody() {
                     </td>
                 </tr>
             )}
-            {blockTime !== undefined && (
+            {blockTime !== undefined && blockTime !== 0 && (
                 <tr>
                     <td className="w-100">Cluster time</td>
                     <td className="text-lg-end font-monospace">

--- a/app/providers/cluster.tsx
+++ b/app/providers/cluster.tsx
@@ -139,11 +139,11 @@ async function updateCluster(dispatch: Dispatch, cluster: Cluster, customUrl: st
         } catch (error) {
             // If getEpochSchedule is not supported, use default devnet values
             epochSchedule = {
-                slotsPerEpoch: 432000n,
-                leaderScheduleSlotOffset: 432000n,
-                warmup: false,
                 firstNormalEpoch: 0n,
                 firstNormalSlot: 0n,
+                leaderScheduleSlotOffset: 432000n,
+                slotsPerEpoch: 432000n,
+                warmup: false,
             };
         }
 

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -40,6 +40,10 @@ export function microLamportsToLamportsString(microLamports: number | bigint, ma
 }
 
 export function lamportsToSol(lamports: number | bigint): number {
+    if (lamports === undefined || lamports === null) {
+        return 0;
+    }
+    
     if (typeof lamports === 'number') {
         return lamports / LAMPORTS_PER_SOL;
     }


### PR DESCRIPTION
The explorer didn't display the accounts page and transactions page correctly (see [original report](https://nitro-svm.slack.com/archives/C08U2F6FMNG/p1750353889011769)) due to the fact that the epochs endpoint isn't supported on the rollup. This PR separates that from a `Promise.all` and sets a default value so that the entire process doesn't just error out.

_Authored mostly by Claude Code._