### PR TITLE
chore: Re-enable mainnet on cluster toggle

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -216,7 +216,7 @@ function AddressLayoutInner({ children, params: { address } }: Props) {
         if (!info && status === ClusterStatus.Connected && pubkey) {
             fetchAccount(pubkey, 'parsed');
         }
-    }, [address, status]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [address, status, info, fetchAccount]);
 
     return (
         <div className="container mt-n3">

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -216,7 +216,7 @@ function AddressLayoutInner({ children, params: { address } }: Props) {
         if (!info && status === ClusterStatus.Connected && pubkey) {
             fetchAccount(pubkey, 'parsed');
         }
-    }, [address, status, info, fetchAccount]);
+    }, [address, status]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <div className="container mt-n3">

--- a/app/utils/cluster.ts
+++ b/app/utils/cluster.ts
@@ -11,9 +11,9 @@ export enum Cluster {
     Custom,
 }
 
-// for now, we only support devnet
+// we don't have a testnet cluster
 // export const CLUSTERS = [Cluster.MainnetBeta, Cluster.Testnet, Cluster.Devnet, Cluster.Custom];
-export const CLUSTERS = [Cluster.Devnet, Cluster.Custom];
+export const CLUSTERS = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Custom];
 
 
 export function clusterSlug(cluster: Cluster): string {
@@ -67,4 +67,4 @@ export function clusterUrl(cluster: Cluster, customUrl: string): string {
     }
 }
 
-export const DEFAULT_CLUSTER = Cluster.Devnet; // Cluster.MainnetBeta;
+export const DEFAULT_CLUSTER = Cluster.MainnetBeta;


### PR DESCRIPTION
We now have a mainnet instance, so we can re-enable it.