### PR TITLE
chore: update transaction count to use endpoint instead of mocked data

### DIFF
--- a/app/providers/stats/solanaClusterStats.tsx
+++ b/app/providers/stats/solanaClusterStats.tsx
@@ -120,16 +120,13 @@ export function SolanaClusterStatsProvider({ children }: Props) {
             }
         };
 
-        // Mock transaction count instead of fetching
         const getTransactionCount = async () => {
             try {
-                // Use a mock transaction count
-                const mockTransactionCount = BigInt(1000000);  // 1 million transactions
-                
+                const transactionCount = await rpc.getTransactionCount({ commitment: 'confirmed' }).send();
                 if (stale) return;
                 
                 dispatchPerformanceInfo({
-                    data: mockTransactionCount,
+                    data: transactionCount,
                     type: PerformanceInfoActionType.SetTransactionCount,
                 });
             } catch (error) {


### PR DESCRIPTION
We originally added the mock data in #1 since the backend RPC endpoints weren't available and the rollup wasn't live yet. We still don't have an endpoint for `getPerformanceSamples`, but we do have one for [`getTransactionCount`](https://github.com/nitro-svm/svm-rollup/blame/a030b217a08de64125772e8c2c63afc3add4a322/crates/svm/src/rpc/mod.rs#L189-L202) now.

This was surfaced by [this request](https://nitro-svm.slack.com/archives/C080NGBP9V5/p1752829003416929).