### PR TITLE
UI ticker solx changes

### DIFF
--- a/app/components/SupplyCard.tsx
+++ b/app/components/SupplyCard.tsx
@@ -30,21 +30,21 @@ export function SupplyCard() {
 
             <TableCardBody>
                 <tr>
-                    <td className="w-100">Total Supply (SOL)</td>
+                    <td className="w-100">Total Supply (SOLX)</td>
                     <td className="text-lg-end">
                         <SolBalance lamports={supply.total} maximumFractionDigits={0} />
                     </td>
                 </tr>
 
                 <tr>
-                    <td className="w-100">Circulating Supply (SOL)</td>
+                    <td className="w-100">Circulating Supply (SOLX)</td>
                     <td className="text-lg-end">
                         <SolBalance lamports={supply.circulating} maximumFractionDigits={0} />
                     </td>
                 </tr>
 
                 <tr>
-                    <td className="w-100">Non-Circulating Supply (SOL)</td>
+                    <td className="w-100">Non-Circulating Supply (SOLX)</td>
                     <td className="text-lg-end">
                         <SolBalance lamports={supply.nonCirculating} maximumFractionDigits={0} />
                     </td>

--- a/app/components/TopAccountsCard.tsx
+++ b/app/components/TopAccountsCard.tsx
@@ -92,7 +92,7 @@ export function TopAccountsCard() {
                                 <tr>
                                     <th className="text-muted">Rank</th>
                                     <th className="text-muted">Address</th>
-                                    <th className="text-muted text-end">Balance (SOL)</th>
+                                    <th className="text-muted text-end">Balance (SOLX)</th>
                                     <th className="text-muted text-end">% of {header} Supply</th>
                                 </tr>
                             </thead>

--- a/app/components/account/StakeAccountSection.tsx
+++ b/app/components/account/StakeAccountSection.tsx
@@ -110,13 +110,13 @@ function OverviewCard({
                     </td>
                 </tr>
                 <tr>
-                    <td>Balance (SOL)</td>
+                    <td>Balance (SOLX)</td>
                     <td className="text-lg-end text-uppercase">
                         <SolBalance lamports={account.lamports} />
                     </td>
                 </tr>
                 <tr>
-                    <td>Rent Reserve (SOL)</td>
+                    <td>Rent Reserve (SOLX)</td>
                     <td className="text-lg-end">
                         <SolBalance lamports={stakeAccount.meta.rentExemptReserve} />
                     </td>
@@ -171,7 +171,7 @@ function DelegationCard({
                 {stake && (
                     <>
                         <tr>
-                            <td>Delegated Stake (SOL)</td>
+                            <td>Delegated Stake (SOLX)</td>
                             <td className="text-lg-end">
                                 <SolBalance lamports={stake.delegation.stake} />
                             </td>
@@ -180,14 +180,14 @@ function DelegationCard({
                         {activation && (
                             <>
                                 <tr>
-                                    <td>Active Stake (SOL)</td>
+                                    <td>Active Stake (SOLX)</td>
                                     <td className="text-lg-end">
                                         <SolBalance lamports={activation.active} />
                                     </td>
                                 </tr>
 
                                 <tr>
-                                    <td>Inactive Stake (SOL)</td>
+                                    <td>Inactive Stake (SOLX)</td>
                                     <td className="text-lg-end">
                                         <SolBalance lamports={activation.inactive} />
                                     </td>

--- a/app/components/account/StakeHistoryCard.tsx
+++ b/app/components/account/StakeHistoryCard.tsx
@@ -21,9 +21,9 @@ export function StakeHistoryCard({ sysvarAccount }: { sysvarAccount: SysvarAccou
                         <thead>
                             <tr>
                                 <th className="w-1 text-muted">Epoch</th>
-                                <th className="text-muted">Effective (SOL)</th>
-                                <th className="text-muted">Activating (SOL)</th>
-                                <th className="text-muted">Deactivating (SOL)</th>
+                                <th className="text-muted">Effective (SOLX)</th>
+                                <th className="text-muted">Activating (SOLX)</th>
+                                <th className="text-muted">Deactivating (SOLX)</th>
                             </tr>
                         </thead>
                         <tbody className="list">

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -424,7 +424,7 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
 
     useEffect(() => {
         if (info.isNative) {
-            setSymbol('SOL');
+            setSymbol('SOLX');
         } else {
             setSymbol(tokenInfo?.symbol);
         }
@@ -479,7 +479,7 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
                 </tr>
                 {info.rentExemptReserve && (
                     <tr>
-                        <td>Rent-exempt reserve (SOL)</td>
+                        <td>Rent-exempt reserve (SOLX)</td>
                         <td className="text-lg-end">
                             <>
                                 ◎

--- a/app/components/account/UnknownAccountCard.tsx
+++ b/app/components/account/UnknownAccountCard.tsx
@@ -30,7 +30,7 @@ export function UnknownAccountCard({ account }: { account: Account }) {
                     </tr>
                 )}
                 <tr>
-                    <td>Balance (SOL)</td>
+                    <td>Balance (SOLX)</td>
                     <td className="text-lg-end">
                         {account.lamports === 0 ? 'Account does not exist' : <SolBalance lamports={account.lamports} />}
                     </td>

--- a/app/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/app/components/account/UpgradeableLoaderAccountSection.tsx
@@ -98,7 +98,7 @@ export function UpgradeableProgramSection({
                     </tr>
                 )}
                 <tr>
-                    <td>Balance (SOL)</td>
+                    <td>Balance (SOLX)</td>
                     <td className="text-lg-end text-uppercase">
                         <SolBalance lamports={account.lamports} />
                     </td>
@@ -224,7 +224,7 @@ export function UpgradeableProgramDataSection({
                     </td>
                 </tr>
                 <tr>
-                    <td>Balance (SOL)</td>
+                    <td>Balance (SOLX)</td>
                     <td className="text-lg-end text-uppercase">
                         <SolBalance lamports={account.lamports} />
                     </td>
@@ -288,7 +288,7 @@ export function UpgradeableProgramBufferSection({
                     </td>
                 </tr>
                 <tr>
-                    <td>Balance (SOL)</td>
+                    <td>Balance (SOLX)</td>
                     <td className="text-lg-end text-uppercase">
                         <SolBalance lamports={account.lamports} />
                     </td>

--- a/app/components/account/address-lookup-table/AddressLookupTableAccountSection.tsx
+++ b/app/components/account/address-lookup-table/AddressLookupTableAccountSection.tsx
@@ -50,7 +50,7 @@ export function AddressLookupTableAccountSection(
                     </td>
                 </tr>
                 <tr>
-                    <td>Balance (SOL)</td>
+                    <td>Balance (SOLX)</td>
                     <td className="text-lg-end text-uppercase">
                         <SolBalance lamports={account.lamports} />
                     </td>

--- a/app/components/common/Account.tsx
+++ b/app/components/common/Account.tsx
@@ -41,7 +41,7 @@ export function AccountBalanceRow({ account }: AccountProps) {
     const { lamports } = account;
     return (
         <tr>
-            <td>Balance (SOL)</td>
+            <td>Balance (SOLX)</td>
             <td className="text-lg-end text-uppercase">
                 <SolBalance lamports={lamports} />
             </td>

--- a/app/components/common/SolBalance.tsx
+++ b/app/components/common/SolBalance.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 
 export function SolBalance({
     lamports,
-    maximumFractionDigits = 9,
+    maximumFractionDigits = 6,
 }: {
     lamports: number | bigint;
     maximumFractionDigits?: number;
 }) {
     return (
         <span>
-            ◎<span className="font-monospace">{lamportsToSolString(lamports, maximumFractionDigits)}</span>
+            <span className="font-monospace">{lamportsToSolString(lamports, maximumFractionDigits)}</span> SOLX
         </span>
     );
 }

--- a/app/components/inspector/AddressWithContext.tsx
+++ b/app/components/inspector/AddressWithContext.tsx
@@ -101,7 +101,7 @@ function AccountInfo({ pubkey, validator }: { pubkey: PublicKey; validator?: Acc
     return (
         <span className="text-muted">
             {`Owned by ${ownerLabel || ownerAddress}.`}
-            {` Balance is ${lamportsToSolString(account.lamports)} SOL.`}
+            {` Balance is ${lamportsToSolString(account.lamports)} SOLX.`}
             {account.space !== undefined && ` Size is ${new Intl.NumberFormat('en-US').format(account.space)} byte(s).`}
         </span>
     );

--- a/app/components/instruction/ComputeBudgetDetailsCard.tsx
+++ b/app/components/instruction/ComputeBudgetDetailsCard.tsx
@@ -52,7 +52,7 @@ export function ComputeBudgetDetailsCard({
                         </tr>
 
                         <tr>
-                            <td>Additional Fee (SOL)</td>
+                            <td>Additional Fee (SOLX)</td>
                             <td className="text-lg-end">
                                 <SolBalance lamports={additionalFee} />
                             </td>

--- a/app/components/instruction/stake/SplitDetailsCard.tsx
+++ b/app/components/instruction/stake/SplitDetailsCard.tsx
@@ -54,7 +54,7 @@ export function SplitDetailsCard(props: {
             </tr>
 
             <tr>
-                <td>Split Amount (SOL)</td>
+                <td>Split Amount (SOLX)</td>
                 <td className="text-lg-end">
                     <SolBalance lamports={info.lamports} />
                 </td>

--- a/app/components/instruction/stake/WithdrawDetailsCard.tsx
+++ b/app/components/instruction/stake/WithdrawDetailsCard.tsx
@@ -54,7 +54,7 @@ export function WithdrawDetailsCard(props: {
             </tr>
 
             <tr>
-                <td>Withdraw Amount (SOL)</td>
+                <td>Withdraw Amount (SOLX)</td>
                 <td className="text-lg-end">
                     <SolBalance lamports={info.lamports} />
                 </td>

--- a/app/components/instruction/system/CreateDetailsCard.tsx
+++ b/app/components/instruction/system/CreateDetailsCard.tsx
@@ -47,7 +47,7 @@ export function CreateDetailsCard(props: {
             </tr>
 
             <tr>
-                <td>Transfer Amount (SOL)</td>
+                <td>Transfer Amount (SOLX)</td>
                 <td className="text-lg-end">
                     <SolBalance lamports={info.lamports} />
                 </td>

--- a/app/components/instruction/system/CreateWithSeedDetailsCard.tsx
+++ b/app/components/instruction/system/CreateWithSeedDetailsCard.tsx
@@ -64,7 +64,7 @@ export function CreateWithSeedDetailsCard(props: {
             </tr>
 
             <tr>
-                <td>Transfer Amount (SOL)</td>
+                <td>Transfer Amount (SOLX)</td>
                 <td className="text-lg-end">
                     <SolBalance lamports={info.lamports} />
                 </td>

--- a/app/components/instruction/system/NonceWithdrawDetailsCard.tsx
+++ b/app/components/instruction/system/NonceWithdrawDetailsCard.tsx
@@ -54,7 +54,7 @@ export function NonceWithdrawDetailsCard(props: {
             </tr>
 
             <tr>
-                <td>Withdraw Amount (SOL)</td>
+                <td>Withdraw Amount (SOLX)</td>
                 <td className="text-lg-end">
                     <SolBalance lamports={info.lamports} />
                 </td>

--- a/app/components/instruction/system/TransferDetailsCard.tsx
+++ b/app/components/instruction/system/TransferDetailsCard.tsx
@@ -47,7 +47,7 @@ export function TransferDetailsCard(props: {
             </tr>
 
             <tr>
-                <td>Transfer Amount (SOL)</td>
+                <td>Transfer Amount (SOLX)</td>
                 <td className="text-lg-end">
                     <SolBalance lamports={info.lamports} />
                 </td>

--- a/app/components/instruction/system/TransferWithSeedDetailsCard.tsx
+++ b/app/components/instruction/system/TransferWithSeedDetailsCard.tsx
@@ -55,7 +55,7 @@ export function TransferWithSeedDetailsCard(props: {
             </tr>
 
             <tr>
-                <td>Transfer Amount (SOL)</td>
+                <td>Transfer Amount (SOLX)</td>
                 <td className="text-lg-end">
                     <SolBalance lamports={info.lamports} />
                 </td>

--- a/app/providers/accounts/flagged-accounts.tsx
+++ b/app/providers/accounts/flagged-accounts.tsx
@@ -44,7 +44,7 @@ const INCIDENTS: Record<IncidentId, IncidentDescription> = {
         <>
             <div className="alert alert-danger alert-scam" role="alert">
                 Warning! This account has been flagged by the community as a scam account. Please be cautious sending
-                SOL to this account.
+                SOLX to this account.
             </div>
         </>
     ),

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -442,8 +442,8 @@ function AccountsCard({ signature }: SignatureProps) {
                         <tr>
                             <th className="text-muted">#</th>
                             <th className="text-muted">Address</th>
-                            <th className="text-muted">Change (SOL)</th>
-                            <th className="text-muted">Post Balance (SOL)</th>
+                            <th className="text-muted">Change (SOLX)</th>
+                            <th className="text-muted">Post Balance (SOLX)</th>
                             <th className="text-muted">Details</th>
                         </tr>
                     </thead>

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -320,7 +320,7 @@ function StatusCard({ signature, autoRefresh }: SignatureProps & AutoRefreshProp
 
                 {fee && (
                     <tr>
-                        <td>Fee (SOL)</td>
+                        <td>Fee (SOLX)</td>
                         <td className="text-lg-end">
                             <SolBalance lamports={fee} />
                         </td>

--- a/app/utils/__tests__/lamportsToSol-test.ts
+++ b/app/utils/__tests__/lamportsToSol-test.ts
@@ -1,27 +1,27 @@
 import { LAMPORTS_PER_SOL, lamportsToSol } from '@utils/index';
 
 describe('lamportsToSol', () => {
-    it('0 lamports', () => {
+    it('converts 0 lamports to 0 SOLX', () => {
         expect(lamportsToSol(0)).toBe(0.0);
         expect(lamportsToSol(BigInt(0))).toBe(0.0);
     });
 
-    it('1 lamport', () => {
-        expect(lamportsToSol(1)).toBe(0.000000001);
-        expect(lamportsToSol(BigInt(1))).toBe(0.000000001);
-        expect(lamportsToSol(-1)).toBe(-0.000000001);
-        expect(lamportsToSol(BigInt(-1))).toBe(-0.000000001);
+    it('converts small lamport amounts to SOLX', () => {
+        expect(lamportsToSol(1)).toBe(0.000001);
+        expect(lamportsToSol(BigInt(1))).toBe(0.000001);
+        expect(lamportsToSol(-1)).toBe(-0.000001);
+        expect(lamportsToSol(BigInt(-1))).toBe(-0.000001);
     });
 
-    it('1 SOL', () => {
+    it('converts 1 SOLX worth of lamports to 1.0', () => {
         expect(lamportsToSol(LAMPORTS_PER_SOL)).toBe(1.0);
         expect(lamportsToSol(BigInt(LAMPORTS_PER_SOL))).toBe(1.0);
         expect(lamportsToSol(-LAMPORTS_PER_SOL)).toBe(-1.0);
         expect(lamportsToSol(BigInt(-LAMPORTS_PER_SOL))).toBe(-1.0);
     });
 
-    it('u64::MAX lamports', () => {
-        expect(lamportsToSol(2n ** 64n)).toBe(18446744073.709553);
-        expect(lamportsToSol(-(2n ** 64n))).toBe(-18446744073.709553);
+    it('handles large numbers', () => {
+        expect(lamportsToSol(2n ** 64n)).toBe(18446744073709.55);
+        expect(lamportsToSol(-(2n ** 64n))).toBe(-18446744073709.55);
     });
 });

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -2,7 +2,7 @@ import { PublicKey, TransactionSignature } from '@solana/web3.js';
 import { HumanizeDuration, HumanizeDurationLanguage } from 'humanize-duration-ts';
 
 // Switch to web3 constant when web3 updates superstruct
-export const LAMPORTS_PER_SOL = 1_000_000_000;
+export const LAMPORTS_PER_SOL = 1_000_000;
 export const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000;
 
 export const NUM_TICKS_PER_SECOND = 160;
@@ -55,12 +55,12 @@ export function lamportsToSol(lamports: number | bigint): number {
 
     const absLamports = lamports < 0 ? -lamports : lamports;
     const lamportsString = absLamports.toString(10).padStart(10, '0');
-    const splitIndex = lamportsString.length - 9;
+    const splitIndex = lamportsString.length - 6;
     const solString = lamportsString.slice(0, splitIndex) + '.' + lamportsString.slice(splitIndex);
     return signMultiplier * parseFloat(solString);
 }
 
-export function lamportsToSolString(lamports: number | bigint, maximumFractionDigits = 9): string {
+export function lamportsToSolString(lamports: number | bigint, maximumFractionDigits = 6): string {
     const sol = lamportsToSol(lamports);
     return new Intl.NumberFormat('en-US', { maximumFractionDigits }).format(sol);
 }


### PR DESCRIPTION
### description

- Update LAMPORTS_PER_SOL from 1_000_000_000 to 1_000_000 (6 decimal places)
- Change lamportsToSol function to use 6 decimal precision
- Update SolBalance component to show SOLX symbol on right side
- Change all UI labels from SOL to SOLX (Fee, Additional Fee, Supply labels, etc.)
- Update tests to reflect new 6 decimal precision

**testing**
account bal
<img width="803" height="621" alt="image" src="https://github.com/user-attachments/assets/e37c0dcd-2e35-4003-9869-45e9fe8875d5" />

tx numbers
<img width="772" height="637" alt="image" src="https://github.com/user-attachments/assets/fffa33e2-63cc-4a0a-b6e5-eb0ffd93f2c9" />

transferred 0.1 SOL (100 SOLX)
<img width="762" height="196" alt="image" src="https://github.com/user-attachments/assets/d8b15393-f627-413c-91e2-a9f07d58abe4" />