### PR TITLE
chore: Update messaging

### DIFF
--- a/app/components/account/DomainsCard.tsx
+++ b/app/components/account/DomainsCard.tsx
@@ -20,7 +20,8 @@ export function DomainsCard({ address }: { address: string }) {
     ) {
         return <LoadingCard message="Loading domains" />;
     } else if (!domains || !domainsANS) {
-        return <ErrorCard text="Failed to fetch domains" />;
+        // DNS isn't available by default on custom clusters
+        return <ErrorCard text={`Domains aren't available on ${process.env.NEXT_PUBLIC_APP_NAME ?? 'the network'}`} />;
     }
 
     if (domains.length === 0 && domainsANS.length === 0) {

--- a/app/providers/accounts/tokens.tsx
+++ b/app/providers/accounts/tokens.tsx
@@ -77,21 +77,23 @@ async function fetchAccountTokens(dispatch: Dispatch, pubkey: PublicKey, cluster
         });
 
         // Fetch symbols and logos for tokens
-        const tokenMintInfos = await getTokenInfos(tokens.map(t => t.info.mint), cluster, url);
-        if (tokenMintInfos) {
-            const mappedTokenInfos = Object.fromEntries(tokenMintInfos.map(t => [t.address, {
-                logoURI: t.logoURI,
-                name: t.name,
-                symbol: t.symbol
-            }]))
-            tokens.forEach(t => {
-                const tokenInfo = mappedTokenInfos[t.info.mint.toString()]
-                if (tokenInfo) {
-                    t.logoURI = tokenInfo.logoURI ?? undefined;
-                    t.symbol = tokenInfo.symbol;
-                    t.name = tokenInfo.name;
-                }
-            })
+        if (tokens.length > 0) {
+            const tokenMintInfos = await getTokenInfos(tokens.map(t => t.info.mint), cluster, url);
+            if (tokenMintInfos) {
+                const mappedTokenInfos = Object.fromEntries(tokenMintInfos.map(t => [t.address, {
+                    logoURI: t.logoURI,
+                    name: t.name,
+                    symbol: t.symbol
+                }]))
+                tokens.forEach(t => {
+                    const tokenInfo = mappedTokenInfos[t.info.mint.toString()]
+                    if (tokenInfo) {
+                        t.logoURI = tokenInfo.logoURI ?? undefined;
+                        t.symbol = tokenInfo.symbol;
+                        t.name = tokenInfo.name;
+                    }
+                })
+            }
         }
 
         data = {

--- a/app/utils/ans-domains.tsx
+++ b/app/utils/ans-domains.tsx
@@ -24,7 +24,8 @@ export const useUserANSDomains = (userAddress: string): [DomainInfo[] | null, bo
                 const parser = new TldParser(connection);
                 const allDomains = await parser.getAllUserDomains(userAddress);
 
-                if (!allDomains) {
+                if (!allDomains || allDomains.length === 0) {
+                    setResult([]);
                     return;
                 }
                 const userDomains: DomainInfo[] = [];

--- a/app/utils/ans-domains.tsx
+++ b/app/utils/ans-domains.tsx
@@ -25,7 +25,6 @@ export const useUserANSDomains = (userAddress: string): [DomainInfo[] | null, bo
                 const allDomains = await parser.getAllUserDomains(userAddress);
 
                 if (!allDomains || allDomains.length === 0) {
-                    setResult([]);
                     return;
                 }
                 const userDomains: DomainInfo[] = [];


### PR DESCRIPTION
The previous token and domain messages show "Failed to fetch token holdings" and "Failed to fetch domain" respectively, which may be confusing to the user.

This PR updates the token checks to return early and avoid fetching token info if the token doesn't exist, and it changes the domain message since there are no DNS contracts by default. Tested locally.